### PR TITLE
Add ability to synchronously create a document list with persisted data

### DIFF
--- a/example/field_options.dart
+++ b/example/field_options.dart
@@ -29,13 +29,12 @@ class _TaskerHomePageState extends State<TaskerHomePage> {
   initState() {
     DocumentList inputList = DocumentList(
       "task types",
-      initialDocuments: [
-        Document(initialValues: {"name": "Shopping"}),
-        Document(initialValues: {"name": "House Work"}),
-        Document(initialValues: {"name": "Errands"}),
-        Document(initialValues: {"name": "School"}),
-      ],
     );
+
+    List<String> categories = ["Shopping", "House Work", "Errands", "Shool"];
+    categories.forEach((String cat) {
+      inputList.add(Document(initialValues: {"name": cat}));
+    });
 
     documentList = DocumentList(
       "tasker",

--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -73,13 +73,11 @@ class Document extends MapBase<String, dynamic> with ChangeNotifier {
     save();
   }
 
-  Future<bool> save() async {
+  Future save() async {
     if (persistenceProvider != null) {
-      bool result = await persistenceProvider.saveDocument(this);
+      await persistenceProvider.saveDocument(this);
       notifyListeners();
-      return result;
     }
-    return false;
   }
 
   delete() {

--- a/lib/src/document_list.dart
+++ b/lib/src/document_list.dart
@@ -11,8 +11,12 @@ import 'package:flutter/foundation.dart';
 /// contains. The document_widgets library can render useful UI elements
 /// for a DocumentList.
 class DocumentList extends ListBase<Document> with ChangeNotifier {
+
+  /// Create a DocumentList for a given docType string. Useful for
+  /// loading data syncronously. For example:
+  /// DocumentList documentList = await DocumentList.createDocumentList("myDocType");
   static Future<DocumentList> createDocumentList(String docType) async {
-    DocumentList documentList = DocumentList(docType);
+    DocumentList documentList = DocumentList(docType, autoLoad: false);
     await documentList.loadPersistedDocuments();
     return documentList;
   }
@@ -36,13 +40,6 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
   /// circumstances, most commonly in a DocumentForm. fieldOptionsMap is
   /// map of field names to objects that are subclass of FieldOptions.
   Map<String, FieldOptions> fieldOptionsMap;
-
-  /// Optional list of Documents to initialize the DocumentList.
-  /// Whenever the DocumentList first initializes, if there are no
-  /// existing Documents already persisted, the DocumentList will
-  /// initialize itself with this list of Documents. If there are
-  /// are one for more Documents already persisted, this property
-  /// will be ignored.
 
   /// How to provide persistence. Defaults to LocalFileProvider
   /// which will save the documents as files on the device.
@@ -73,14 +70,14 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
   /// The documentType parameter should be unique.
   DocumentList(this.documentType,
       {this.onLoadComplete,
-      List<Document> initialDocuments,
       Map<String, String> labels,
       this.fieldOptionsMap,
+      bool autoLoad = true,
       this.persistenceProvider = const LocalFilePersistence()}) {
     _labels = labels;
     _documents = [];
-    if (initialDocuments != null) {
-      addAll(initialDocuments);
+    if(autoLoad){
+      this.loadPersistedDocuments();
     }
   }
 

--- a/lib/src/document_list.dart
+++ b/lib/src/document_list.dart
@@ -11,7 +11,7 @@ import 'package:flutter/foundation.dart';
 /// contains. The document_widgets library can render useful UI elements
 /// for a DocumentList.
 class DocumentList extends ListBase<Document> with ChangeNotifier {
-  static Future<DocumentList> getPersistedDocumentList(String docType) async {
+  static Future<DocumentList> createDocumentList(String docType) async {
     DocumentList documentList = DocumentList(docType);
     await documentList.loadPersistedDocuments();
     return documentList;
@@ -43,7 +43,6 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
   /// initialize itself with this list of Documents. If there are
   /// are one for more Documents already persisted, this property
   /// will be ignored.
-  final List<Document> initialDocuments;
 
   /// How to provide persistence. Defaults to LocalFileProvider
   /// which will save the documents as files on the device.
@@ -74,12 +73,15 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
   /// The documentType parameter should be unique.
   DocumentList(this.documentType,
       {this.onLoadComplete,
-      this.initialDocuments,
+      List<Document> initialDocuments,
       Map<String, String> labels,
       this.fieldOptionsMap,
       this.persistenceProvider = const LocalFilePersistence()}) {
     _labels = labels;
     _documents = [];
+    if (initialDocuments != null) {
+      addAll(initialDocuments);
+    }
   }
 
   set labels(Map<String, String> labels) {
@@ -210,10 +212,6 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
   Future loadPersistedDocuments() async {
     if (persistenceProvider != null) {
       await persistenceProvider.loadDocuments(this);
-    }
-
-    if (_documents.length == 0 && initialDocuments != null) {
-      addAll(this.initialDocuments);
     }
     _signalLoadComplete();
   }

--- a/lib/src/document_list.dart
+++ b/lib/src/document_list.dart
@@ -1,5 +1,6 @@
 library rapido;
 
+import 'dart:async';
 import 'dart:collection';
 import 'dart:math';
 import 'package:rapido/rapido.dart';
@@ -10,6 +11,12 @@ import 'package:flutter/foundation.dart';
 /// contains. The document_widgets library can render useful UI elements
 /// for a DocumentList.
 class DocumentList extends ListBase<Document> with ChangeNotifier {
+  static Future<DocumentList> getPersistedDocumentList(String docType) async {
+    DocumentList documentList = DocumentList(docType);
+    await documentList.loadPersistedDocuments();
+    return documentList;
+  }
+
   /// A unique string identifying the documents organized by the list.
   final String documentType;
 
@@ -73,7 +80,6 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
       this.persistenceProvider = const LocalFilePersistence()}) {
     _labels = labels;
     _documents = [];
-    _loadPersistedDocuments();
   }
 
   set labels(Map<String, String> labels) {
@@ -101,7 +107,7 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
   }
 
   @override
-  void add(Document doc, {saveOnAdd = true}) {
+  add(Document doc, {bool saveOnAdd = true}) async {
     doc.persistenceProvider = persistenceProvider;
     if (saveOnAdd) {
       doc["_docType"] = documentType;
@@ -201,17 +207,15 @@ class DocumentList extends ListBase<Document> with ChangeNotifier {
     return new String.fromCharCodes(codeUnits);
   }
 
-  void _loadPersistedDocuments() async {
+  Future loadPersistedDocuments() async {
     if (persistenceProvider != null) {
       await persistenceProvider.loadDocuments(this);
     }
 
     if (_documents.length == 0 && initialDocuments != null) {
       addAll(this.initialDocuments);
-      _signalLoadComplete();
-    } else {
-      _signalLoadComplete();
     }
+    _signalLoadComplete();
   }
 
   void _signalLoadComplete() {

--- a/lib/src/document_list_view.dart
+++ b/lib/src/document_list_view.dart
@@ -113,6 +113,7 @@ customItemBuilder to the DocumentListView.
         // if the user hasn't defined a subtitle key
         // then assume they want a field call "subtitle"
         // to be in the subtitle, and not in the title
+
         if (widget.subtitleKey == null) {
           if (key == "subtitle") {
             skip = true;

--- a/lib/src/parse_persistence.dart
+++ b/lib/src/parse_persistence.dart
@@ -56,7 +56,7 @@ class ParsePersistence implements PersistenceProvider {
   }
 
   @override
-  Future saveDocument(Document doc) async {
+  saveDocument(Document doc) async {
     ParseObject obj = _parseObjectFromDocument(doc);
     if (doc["objectId"] == null) {
       ParseResponse response = await obj.create();

--- a/lib/src/parse_persistence.dart
+++ b/lib/src/parse_persistence.dart
@@ -17,7 +17,7 @@ class ParsePersistence implements PersistenceProvider {
     if (doc["objectId"] == null) return null;
     ParseObject obj = _parseObjectFromDocument(doc);
     String path = "${doc.documentType}/${doc.id}";
-    obj.delete(path:path);
+    obj.delete(path: path);
     return null;
   }
 
@@ -56,17 +56,15 @@ class ParsePersistence implements PersistenceProvider {
   }
 
   @override
-  Future<bool> saveDocument(Document doc) {
+  Future saveDocument(Document doc) async {
     ParseObject obj = _parseObjectFromDocument(doc);
     if (doc["objectId"] == null) {
-      obj.create().then((ParseResponse responts) {
-        ParseObject newObj = responts.result;
-        doc["objectId"] = newObj.objectId;
-      });
+      ParseResponse response = await obj.create();
+      ParseObject newObj = response.result;
+      doc["objectId"] = newObj.objectId;
     } else {
-      obj.save();
+      await obj.save();
     }
-    return null;
   }
 
   ParseObject _parseObjectFromDocument(Document doc) {

--- a/lib/src/persistence.dart
+++ b/lib/src/persistence.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 import 'dart:convert';
 
 abstract class PersistenceProvider {
-  Future<bool> saveDocument(Document doc);
+  Future saveDocument(Document doc);
   Future loadDocuments(DocumentList documentList, {Function onChangedListener});
   Future deleteDocument(Document doc);
 }
@@ -13,13 +13,10 @@ abstract class PersistenceProvider {
 class LocalFilePersistence implements PersistenceProvider {
   const LocalFilePersistence();
 
-  Future<bool> saveDocument(Document doc) async {
+  Future saveDocument(Document doc) async {
     final file = await _localFile(doc["_id"]);
-    // Write the file
     String mapString = json.encode(doc);
-    file.writeAsString('$mapString');
-
-    return true;
+    file.writeAsStringSync('$mapString');
   }
 
   Future loadDocuments(DocumentList documentList,

--- a/lib/src/persistence.dart
+++ b/lib/src/persistence.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 import 'dart:convert';
 
 abstract class PersistenceProvider {
-  Future saveDocument(Document doc);
+  saveDocument(Document doc);
   Future loadDocuments(DocumentList documentList, {Function onChangedListener});
   Future deleteDocument(Document doc);
 }
@@ -13,7 +13,7 @@ abstract class PersistenceProvider {
 class LocalFilePersistence implements PersistenceProvider {
   const LocalFilePersistence();
 
-  Future saveDocument(Document doc) async {
+  saveDocument(Document doc) async {
     final file = await _localFile(doc["_id"]);
     String mapString = json.encode(doc);
     file.writeAsStringSync('$mapString');

--- a/test/document_list_test.dart
+++ b/test/document_list_test.dart
@@ -243,19 +243,6 @@ void main() {
     expect(brokenList[1]["b"] == 1, true);
   });
 
-  test('initialDocuments test', () {
-    List<Document> docs = [
-      Document(initialValues: {"a": 1}),
-      Document(initialValues: {"b": 2}),
-      Document(initialValues: {"c": 3}),
-      Document(initialValues: {"d": 4}),
-    ];
-    DocumentList documentList =
-        DocumentList("initializeMe", initialDocuments: docs);
-
-    expect(documentList.length, docs.length);
-  });
-
   test('empty DocumentList documentsLoaded property', () async {
     DocumentList documentList = DocumentList("empty");
     expect(documentList.documentsLoaded, false);

--- a/test/document_list_test.dart
+++ b/test/document_list_test.dart
@@ -7,7 +7,8 @@ import 'package:rapido/rapido.dart';
 void main() {
   flutterTest.TestWidgetsFlutterBinding.ensureInitialized();
   test('create and read a DocumentList sync', () async {
-    DocumentList documentList = DocumentList("testDocumentType");
+    DocumentList documentList =
+        await DocumentList.createDocumentList("testDocumentType");
     documentList.add(
       Document(initialValues: {
         "count": 0,
@@ -27,7 +28,7 @@ void main() {
     expect(documentList.length, 2);
 
     DocumentList loadedDocumentList =
-        await DocumentList.getPersistedDocumentList("testDocumentType");
+        await DocumentList.createDocumentList("testDocumentType");
     expect(loadedDocumentList.length, 2);
     String name = loadedDocumentList[0]["name"];
     expect(name.contains("Rick"), true);
@@ -36,27 +37,20 @@ void main() {
     expect(loadedDocumentList[0]["price"], 1.5);
   });
 
-  test('onChanged works', () {
-    DocumentList list = DocumentList("onchange");
-    list.addListener(() {
-      expect(list.length, 1);
-    });
-    list.add(Document(initialValues: {"a": 1}));
-  });
   test('tests that any() works', () async {
     DocumentList loadedDocumentList =
-        await DocumentList.getPersistedDocumentList("testDocumentType");
+        await DocumentList.createDocumentList("testDocumentType");
     bool c = loadedDocumentList.any((Map<String, dynamic> map) {
       return map.containsValue("Rick Sanchez");
     });
     expect(c, true);
   });
 
-  test('foreach()', () {
-    DocumentList("addAllTest", onLoadComplete: (DocumentList model) {
-      model.forEach((Map<String, dynamic> map) {
-        expect(map["name"].toString().contains("Rick"), true);
-      });
+  test('foreach()', () async {
+    DocumentList documentList =
+        await DocumentList.createDocumentList("addAllTest");
+    documentList.forEach((Map<String, dynamic> map) {
+      expect(map["name"].toString().contains("Rick"), true);
     });
   });
 
@@ -78,50 +72,48 @@ void main() {
     expect(list[2]["a"], 3);
   });
 
-  test('test []= operator, document is completely replaced', () {
-    DocumentList("testDocumentType",
-        onLoadComplete: (DocumentList documentList) {
-      Document updatedDoc = Document(
-          initialValues: {"count": 1, "price": 2.5, "name": "Edited Name"});
-      int oldTimeStamp = documentList[0]["_time_stamp"];
-      String oldId = documentList[0]["_id"];
-      documentList[0] = updatedDoc;
-      expect(documentList[0]["count"], 1);
-      expect(documentList[0]["rating"], null);
-      expect(documentList[0]["price"], 2.5);
-      expect(documentList[0]["name"], "Edited Name");
-      expect(documentList[0]["_time_stamp"], greaterThan(oldTimeStamp));
-      expect(oldId == documentList[0]["_id"], false);
-    });
+  test('test []= operator, document is completely replaced', () async {
+    DocumentList documentList =
+        await DocumentList.createDocumentList("testDocumentType");
+    Document updatedDoc = Document(
+        initialValues: {"count": 1, "price": 2.5, "name": "Edited Name"});
+    int oldTimeStamp = documentList[0]["_time_stamp"];
+    String oldId = documentList[0]["_id"];
+    documentList[0] = updatedDoc;
+    expect(documentList[0]["count"], 1);
+    expect(documentList[0]["rating"], null);
+    expect(documentList[0]["price"], 2.5);
+    expect(documentList[0]["name"], "Edited Name");
+    expect(documentList[0]["_time_stamp"], greaterThan(oldTimeStamp));
+    expect(oldId == documentList[0]["_id"], false);
   });
 
-  test('checks that operator []=  persist on disk', () {
-    DocumentList("testDocumentType", onLoadComplete: (DocumentList dl) {
-      bool testMapFound = false;
-      dl.forEach((Document doc) {
-        if (doc["name"] == "Edited Name") {
-          expect(doc["count"], 1);
-          expect(doc["rating"], null);
-          expect(doc["price"], 2.5);
-          testMapFound = true;
-        }
-      });
-      expect(testMapFound, true);
+  test('checks that operator []=  persist on disk', () async {
+    DocumentList documentList =
+        await DocumentList.createDocumentList("testDocumentType");
+    bool testMapFound = false;
+    documentList.forEach((Document doc) {
+      if (doc["name"] == "Edited Name") {
+        expect(doc["count"], 1);
+        expect(doc["rating"], null);
+        expect(doc["price"], 2.5);
+        testMapFound = true;
+      }
     });
+    expect(testMapFound, true);
   });
 
   test('tests removeAt removes documents and returns the removed doc',
       () async {
-    DocumentList("testDocumentType",
-        onLoadComplete: (DocumentList documentList) {
-      Document zeroDoc = documentList[0];
-      Document removedDoc = documentList.removeAt(0);
-      expect(zeroDoc == removedDoc, true);
-      DocumentList("testDocumentType", onLoadComplete: (DocumentList dl) {
-        dl.forEach((Document doc) {
-          expect(doc["_id"] != zeroDoc["_id"], true);
-        });
-      });
+    DocumentList documentList =
+        await DocumentList.createDocumentList("testDocumentType");
+
+    Document zeroDoc = documentList[0];
+    Document removedDoc = documentList.removeAt(0);
+    expect(zeroDoc == removedDoc, true);
+    DocumentList dl = await DocumentList.createDocumentList("testDocumentType");
+    dl.forEach((Document doc) {
+      expect(doc["_id"] != zeroDoc["_id"], true);
     });
   });
 
@@ -144,10 +136,10 @@ void main() {
     expect(list.first["a"], 1);
   });
 
-  test('removeAt() survives persistence', () {
-    DocumentList("removeAtTeest", onLoadComplete: (DocumentList list) {
-      expect(list.length, 9);
-    });
+  test('removeAt() survives persistence', () async {
+    DocumentList documentList =
+        await DocumentList.createDocumentList("removeAtTeest");
+    expect(documentList.length, 9);
   });
 
   test('infer ui labels', () {
@@ -174,23 +166,23 @@ void main() {
     expect(dl.length, 2);
   });
 
-  test('checks that using addAll persists data', () {
-    DocumentList("addAllTest", onLoadComplete: (DocumentList model) {
-      expect(model.length, 2);
-    });
+  test('checks that using addAll persists data', () async {
+    DocumentList documentList =
+        await DocumentList.createDocumentList("addAllTest");
+    expect(documentList.length, 2);
   });
 
-  test('clear()', () {
-    DocumentList("addAllTest", onLoadComplete: (DocumentList model) async {
-      model.clear();
-      expect(model.length, 0);
-    });
+  test('clear()', () async {
+    DocumentList documentList =
+        await DocumentList.createDocumentList("addAllTest");
+    documentList.clear();
+    expect(documentList.length, 0);
   });
 
-  test('test that clear() works across persistence', () {
-    DocumentList("addAllTest", onLoadComplete: (DocumentList model) async {
-      expect(model.length, 0);
-    });
+  test('test that clear() works across persistence', () async {
+    DocumentList documentList =
+        await DocumentList.createDocumentList("addAllTest");
+    expect(documentList.length, 0);
   });
 
   test('remove object', () {
@@ -202,7 +194,6 @@ void main() {
     expect(list.length, 0);
   });
   test('sortByField', () {
-    // TODO: add tests for other field types (date)
     DocumentList list = DocumentList("sortByField");
     List<String> strings = [
       "abcd",
@@ -259,29 +250,18 @@ void main() {
       Document(initialValues: {"c": 3}),
       Document(initialValues: {"d": 4}),
     ];
-    DocumentList("initializeMe", initialDocuments: docs,
-        onLoadComplete: (DocumentList l) {
-      expect(l.length, docs.length);
-    });
+    DocumentList documentList =
+        DocumentList("initializeMe", initialDocuments: docs);
+
+    expect(documentList.length, docs.length);
   });
 
-  test('initialDocuments skipped', () {
-    List<Document> docs = [
-      Document(initialValues: {"a": 1}),
-      Document(initialValues: {"b": 2}),
-      Document(initialValues: {"c": 3}),
-      Document(initialValues: {"d": 4}),
-    ];
-    DocumentList("initializeMe", initialDocuments: docs,
-        onLoadComplete: (DocumentList l) {
-      expect(l.length, 4);
-    });
-  });
+  test('empty DocumentList documentsLoaded property', () async {
+    DocumentList documentList = DocumentList("empty");
+    expect(documentList.documentsLoaded, false);
+    await documentList.loadPersistedDocuments();
+    expect(documentList.documentsLoaded, true);
 
-  test('empty DocumentList documentsLoaded property', () {
-    DocumentList("empty", onLoadComplete: (DocumentList l) {
-      expect(l.documentsLoaded, true);
-    });
   });
 
   test('DocumentList created with no local persistence', () {
@@ -293,10 +273,9 @@ void main() {
     expect(dl[0]["a"], 1);
   });
 
-  test('Documents not saved if local persistence is off', () {
-    DocumentList("no local persistence", onLoadComplete: (list) {
-      expect(list.length, 0);
-    });
+  test('Documents not saved if local persistence is off', () async {
+    DocumentList documentList = await DocumentList.createDocumentList("no local persistence");
+      expect(documentList.length, 0);
   });
 
   setUpAll(() async {

--- a/test/document_list_test.dart
+++ b/test/document_list_test.dart
@@ -6,31 +6,34 @@ import 'package:rapido/rapido.dart';
 
 void main() {
   flutterTest.TestWidgetsFlutterBinding.ensureInitialized();
-  test('creates a DocumentList', () {
+  test('create and read a DocumentList sync', () async {
     DocumentList documentList = DocumentList("testDocumentType");
-    documentList.add(Document(initialValues: {
-      "count": 0,
-      "rating": 5,
-      "price": 1.5,
-      "name": "Pickle Rick"
-    }));
-    documentList.add(Document(initialValues: {
-      "count": 1,
-      "rating": 4,
-      "price": 1.5,
-      "name": "Rick Sanchez"
-    }));
+    documentList.add(
+      Document(initialValues: {
+        "count": 0,
+        "rating": 5,
+        "price": 1.5,
+        "name": "Pickle Rick"
+      }),
+    );
+    documentList.add(
+      Document(initialValues: {
+        "count": 1,
+        "rating": 4,
+        "price": 1.5,
+        "name": "Rick Sanchez"
+      }),
+    );
     expect(documentList.length, 2);
-  });
-  test('reads existing Documents from disk', () {
-    DocumentList("testDocumentType", onLoadComplete: (DocumentList model) {
-      expect(model.length, 2);
-      String name = model[0]["name"];
-      expect(name.contains("Rick"), true);
-      name = model[1]["name"];
-      expect(name.contains("Rick"), true);
-      expect(model[0]["price"], 1.5);
-    });
+
+    DocumentList loadedDocumentList =
+        await DocumentList.getPersistedDocumentList("testDocumentType");
+    expect(loadedDocumentList.length, 2);
+    String name = loadedDocumentList[0]["name"];
+    expect(name.contains("Rick"), true);
+    name = loadedDocumentList[1]["name"];
+    expect(name.contains("Rick"), true);
+    expect(loadedDocumentList[0]["price"], 1.5);
   });
 
   test('onChanged works', () {
@@ -40,13 +43,13 @@ void main() {
     });
     list.add(Document(initialValues: {"a": 1}));
   });
-  test('tests that any() works', () {
-    DocumentList("testDocumentType", onLoadComplete: (DocumentList model) {
-      bool c = model.any((Map<String, dynamic> map) {
-        return map.containsValue("Rick Sanchez");
-      });
-      expect(c, true);
+  test('tests that any() works', () async {
+    DocumentList loadedDocumentList =
+        await DocumentList.getPersistedDocumentList("testDocumentType");
+    bool c = loadedDocumentList.any((Map<String, dynamic> map) {
+      return map.containsValue("Rick Sanchez");
     });
+    expect(c, true);
   });
 
   test('foreach()', () {
@@ -291,8 +294,7 @@ void main() {
   });
 
   test('Documents not saved if local persistence is off', () {
-    DocumentList dl =
-        DocumentList("no local persistence", onLoadComplete: (list) {
+    DocumentList("no local persistence", onLoadComplete: (list) {
       expect(list.length, 0);
     });
   });

--- a/test/document_list_view_test.dart
+++ b/test/document_list_view_test.dart
@@ -62,42 +62,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(widgetTest.find.text("1"), widgetTest.findsOneWidget);
   });
-  widgetTest.testWidgets('subtitle is used automatically',
-      (widgetTest.WidgetTester tester) async {
-    DocumentList dl = DocumentList("subtitle test");
-    dl.add(Document(initialValues: {"title": "a", "subtitle": "xxxx"}));
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: DocumentListView(
-            dl,
-            titleKeys: ["title"],
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(widgetTest.find.text("xxxx"), widgetTest.findsOneWidget);
-  });
-
-  widgetTest.testWidgets('subtitle is not used in title',
-      (widgetTest.WidgetTester tester) async {
-    DocumentList dl = DocumentList("subtitle test");
-    dl.add(Document(initialValues: {"title": "a", "subtitle": "xxxx"}));
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: DocumentListView(
-            dl,
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(widgetTest.find.text("xxxx"), widgetTest.findsOneWidget);
-  });
   widgetTest.testWidgets('test DocumentList.sort and cutomItemBuilder',
       (widgetTest.WidgetTester tester) async {
     DocumentList dl = DocumentList("sortListTest");


### PR DESCRIPTION
This change supports testability. Previously, tests could easily be pass even if the documents were not loaded because documentsLoaded would not fire if there was an issue loading the documents.

This change allows a test to be written like:

```
    DocumentList loadedDocumentList =
        await DocumentList.createDocumentList("testDocumentType");
    expect(loadedDocumentList.length, 2);
```
so that the expect function will always run after the createDocumentList function runs and completes.

In order to make this work, I added a "autoLoad" parameter which defaults to true in the DocumentList constructor. This is called set to false in the createDocumentList call into the constructor.

I fixed tests to use the new pattern.

While I was fixing those tests, I removed some tests that I realized were useful.
